### PR TITLE
Modify net worth report to hackily project based on scheduled transac…

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -129,10 +129,9 @@ export function withReportContextProvider(InnerComponent) {
           'visibleTransactionDisplayItems'
         );
         const allReportableTransactions = visibleTransactionDisplayItems.filter(
-          transaction =>
-            !transaction.get('isSplit') &&
-            !transaction.get('isScheduledTransaction') &&
-            !transaction.get('isScheduledSubTransaction')
+          transaction => !transaction.get('isSplit')
+          // !transaction.get('isScheduledTransaction') &&
+          // !transaction.get('isScheduledSubTransaction')
         );
 
         this.setState(

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.jsx
@@ -145,7 +145,6 @@ export class DateFilterComponent extends React.Component {
     // we need to convert `.getYear()` into a string.
     while (date.getYear().toString() === selectedYear.toString()) {
       options.push({
-        disabled: date.isAfter(today) || date.isBefore(this.firstMonthOfBudget),
         month: date.getMonth(),
       });
 


### PR DESCRIPTION
I've been using YNAB for years, and have developed a habit of adding scheduled transactions to my budget so I can project account balances ~12 months out. While I understand it's not the 'YNAB Way' to project like this, I always wanted to be able to view my projected net worth based on scheduled transactions.

So, I dug through the Toolkit project and simply altered a couple lines of code! By...

- removing the disabled month options from the HTML-generating `getEligibleMonths()` function of the `DateFilterComponent`
- and removing the logic that excluded scheduled transactions from the `WithReportContextProvider` component's `allReportableTransactions` constant...

I managed to get a simple, hacky projection based on scheduled transactions in my personal budget!